### PR TITLE
Adding DN of eScience CA 3B and 3A for validity check.

### DIFF
--- a/src/main/resources/configure.properties
+++ b/src/main/resources/configure.properties
@@ -34,7 +34,7 @@ ngsca.cert.o=eScience
 # If the keystore cert has a different issuer DN to those listed here, then the check 
 # is skipped for that keystore entry. Only certs that have an issuer DN listed 
 # below will be checked with this query. 
-ngsca.issuer.dn=CN=UK e-Science CA,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2B,OU=Authority,O=eScienceCA,C=UK
+ngsca.issuer.dn=CN=UK e-Science CA,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2B,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 3A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 3B,OU=Authority,O=eScienceCA,C=UK
 # below one not RFC2253:
 #ngsca.issuer.dn=C=UK,O=eScienceDev,OU=NGS,CN=DevelopmentCA
 


### PR DESCRIPTION
## Description

This PR updates the application configuration to recognize the Distinguished Names (DNs) of the new **UK e-Science CA 3A** and **UK e-Science CA 3B** certificate authorities.

Without this update, CertWizard skips validity checks for certificates issued by these newer authorities, causing them to be improperly flagged as `Unknown (offline or certificate not recognised by UK CA` within the client cert interface. Thus, user will not be able to request new host cert, revoke or renewal.

### Key Changes

* **Updated `configure.properties**`: Appended the issuer DNs for `UK e-Science CA 3A` and `UK e-Science CA 3B` to the `ngsca.issuer.dn` semicolon-separated string to `ngsca.issuer.dn`

## Type of Change

Upgrade and bugfix 

## How Has This Been Tested?

The change was verified by 
- Importing a cert issued by UK e-Science 3B (shown valid)
- Requesting a new 2B cert with a 3B user cert
- Requesting a renew of 2B cert to get a 3B cert (shown valid)
- Revoke the 2B cert

*To verify locally:* You can build locally but you need to skip the package for windows and mac step otherwise it will through an error due to missing code signing key