### PR TITLE
`fix-maven-pom-workflow`: Add GitHub Actions build workflow & upgrade to Java 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [25]
         
     runs-on: ubuntu-latest
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,77 @@
+name: Package Multiplatform Installers
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch: # Allows manual triggering from the Actions tab for any branch
+    inputs:
+      test_mode:
+        description: 'Is this a test run? (Saves files to Action run instead of updating a live Release)'
+        type: boolean
+        required: true
+        default: true
+      version_tag:
+        description: 'Release Tag to attach binaries to (Only used if Test Mode is false)'
+        type: string
+        required: false
+        default: 'v2.1.1'
+
+jobs:
+  build-and-package:
+    name: Package for ${{ matrix.friendly-name }}
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            friendly-name: Windows (EXE & Portable Zip)
+            platform-profile: jar-with-dependencies
+            # Captures both the executable setup installer and the portable zip ball
+            artifact-path: |
+              target/CertWizard_*.exe
+              target/CertWizard_*.msi
+              target/CertWizard-windows.zip
+            artifact-name: CertWizard-Windows
+
+          - os: macos-latest
+            friendly-name: macOS (DMG/PKG/Zip)
+            platform-profile: jar-with-dependencies
+            artifact-path: |
+              target/CertWizard-mac.zip
+              target/*.dmg
+              target/*.pkg
+            artifact-name: CertWizard-Mac-App
+
+          - os: ubuntu-latest
+            friendly-name: Linux (JAR)
+            platform-profile: jar-with-dependencies
+            artifact-path: |
+              target/*-jar-with-dependencies.jar
+            artifact-name: CertWizard-Linux-JAR
+
+    steps:
+      # 1. Checkout repository
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      # 2. Set up Java Environment
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: 'maven'
+
+      # 3. Build and Package
+      - name: Build and Native Package with Maven
+        run: mvn clean package -P ${{ matrix.platform-profile }}
+
+      # 4. Archive and upload the generated artifacts
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
+          if-no-files-found: error

--- a/pom.xml
+++ b/pom.xml
@@ -8,27 +8,27 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet</artifactId>
-            <version>2.4.3</version>
+            <version>3.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet.ext.xml</artifactId>
-            <version>2.4.3</version>
+            <version>3.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet.ext.httpclient</artifactId>
-            <version>2.4.3</version>
+            <version>3.0-M1</version>
         </dependency> 
         <dependency>
             <groupId>junit</groupId>
@@ -39,17 +39,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.20.0</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.20.0</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
+            <version>1.10.1</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -61,6 +61,21 @@
             <groupId>com.vdurmont</groupId>
             <artifactId>semver4j</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-digester</groupId>
+            <artifactId>commons-digester</artifactId>
+            <version>2.1</version>
         </dependency>
     </dependencies>
     <repositories>
@@ -77,8 +92,9 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
         <mainClass>uk.ngs.certwizard.gui.CertWizardMain</mainClass>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.ngs</groupId>
     <artifactId>CertWizard</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,13 +80,13 @@
         <maven.compiler.source>1.9</maven.compiler.source>
         <maven.compiler.target>1.9</maven.compiler.target>
         <mainClass>uk.ngs.certwizard.gui.CertWizardMain</mainClass>
-        <codeSignCert>C:\\Users\\fou43474\\OneDrive - Science and Technology Facilities Council\\Documents\\Certs\\UKRICodeSign.p12</codeSignCert>
     </properties>
 
     <licenses>
         <license>
             <name>GPL-2.0</name>
-            <url>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
+            <!--Use Github link to replace old link-->
+            <url>https://github.com/github/choosealicense.com/blob/gh-pages/_licenses/gpl-2.0.txt</url>
         </license>
     </licenses>
 
@@ -152,35 +152,14 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jarsigner-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <execution>
-                                <id>sign</id>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <keystore>${codeSignCert}</keystore>
-                            <!--suppress UnresolvedMavenProperty -->
-                            <storepass>${codesignpass}</storepass>
-                            <!--suppress UnresolvedMavenProperty -->
-                            <keypass>${codesignpass}</keypass>
-                            <alias>000_ukricodesign</alias>
-                        </configuration>
-                    </plugin>
                     
                     <plugin>
                         <groupId>io.github.fvarrui</groupId>
                         <artifactId>javapackager</artifactId>
-                        <version>1.7.5</version>
+                        <version>1.7.6</version>
                         <configuration>
                             <mainClass>${mainClass}</mainClass>
+                            <!-- Global fallback, overridden individually below if needed -->
                             <bundleJre>true</bundleJre>
                             <version>2.1.1</version>
                             <displayName>CertWizard</displayName>
@@ -188,6 +167,7 @@
                             <organizationUrl>https://stfc.ukri.org</organizationUrl>
                             <organizationEmail>support@grid-support.ac.uk</organizationEmail>
                             <name>CertWizard</name>
+                            <licenseFile>${project.basedir}/LICENSE.txt</licenseFile>
                         </configuration>
                         <executions>
                             <execution>
@@ -201,38 +181,31 @@
                                     <createZipball>true</createZipball>
                                     <winConfig>
                                         <generateSetup>true</generateSetup>
-                                        <generateMsi>false</generateMsi>
+                                        <generateMsi>true</generateMsi>
                                         <generateMsm>false</generateMsm>
                                         <originalFilename>CertWizard.exe</originalFilename>
                                         <setupMode>askTheUser</setupMode>
                                         <createDesktopIconTask>true</createDesktopIconTask>
                                         <icoFile>src/main/resources/ngs-icon.ico</icoFile>
                                         <removeOldLibs>true</removeOldLibs>
-                                        <signing>
-                                            <storetype>PKCS12</storetype>
-                                            <keystore>${codeSignCert}</keystore>
-                                            <!--suppress UnresolvedMavenProperty -->
-					                        <storepass>${codesignpass}</storepass>
-					                        <alias>000_ukricodesign</alias>
-                                        </signing>
                                     </winConfig>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>bundling-for-mac</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                                <configuration>
-                                    <platform>mac</platform>
-                                    <createZipball>true</createZipball>
-                                    <jdkPath>C:\jdk\mac\jdk-17.0.6+10\Contents\Home</jdkPath>
-                                    <macConfig>
-                                        <icnsFile>src/main/resources/ngs-icon.icns</icnsFile>
-                                    </macConfig>
-                                </configuration>
-                            </execution>
+                            <id>bundling-for-mac</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                            <configuration>
+                                <platform>mac</platform>
+                                <createZipball>true</createZipball>
+                                <bundleJre>true</bundleJre>
+                                <macConfig>
+                                    <icnsFile>src/main/resources/ngs-icon.icns</icnsFile>
+                                </macConfig>
+                            </configuration>
+                        </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
                             <mainClass>${mainClass}</mainClass>
                             <!-- Global fallback, overridden individually below if needed -->
                             <bundleJre>true</bundleJre>
+                            <customizedJre>false</customizedJre>
                             <version>2.1.1</version>
                             <displayName>CertWizard</displayName>
                             <organizationName>STFC</organizationName>

--- a/src/main/resources/configure.properties
+++ b/src/main/resources/configure.properties
@@ -34,7 +34,7 @@ ngsca.cert.o=eScience
 # If the keystore cert has a different issuer DN to those listed here, then the check 
 # is skipped for that keystore entry. Only certs that have an issuer DN listed 
 # below will be checked with this query. 
-ngsca.issuer.dn=CN=UK e-Science CA,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2B,OU=Authority,O=eScienceCA,C=UK
+ngsca.issuer.dn=CN=UK e-Science CA,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 2B,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 3A,OU=Authority,O=eScienceCA,C=UK;CN=UK e-Science CA 3B,OU=Authority,O=eScienceCA,C=UK
 # below one not RFC2253:
 #ngsca.issuer.dn=C=UK,O=eScienceDev,OU=NGS,CN=DevelopmentCA
 


### PR DESCRIPTION
## Description

### Overview

This PR updates the build configuration and dependency stack to support **Java 25**, cleans up legacy hardcoded build logic in the `pom.xml`, and introduces an automated GitHub Actions CI workflow (`package.yml`) for building Maven packages for Windows, MacOS and Linux JAR.

Additionally, this branch includes integrated testing that incorporates changes from **PR #62** and **PR #63**.

---

### Key Changes

* **GitHub Actions CI/CD Workflow (`package.yml`)**:
    * Created `.github/workflows/package.yml` to automate building and packaging via GitHub Actions.
    * After merging to main the [Package Multiplatform Installers](https://github.com/stfc/CertWizard/actions/workflows/package.yml) action can be manually triggered on any branch to test


* **Maven & POM Refactoring**:
    * Upgraded project dependencies and plugin configurations to support **Java 25**.
    * Removed all hardcoded system paths and hardcoded build logic from `pom.xml` to ensure clean, environment-agnostic local and CI builds.
    * Updated version number to `2.2.0` with semantic versioning schema



---

### Integrated Pull Requests (for Testing)

This branch aggregates and validates changes from the following PRs:

* **#62** (`Update java and other dependencies` by @garaimanoj): Dependency and Java 25 toolchain updates.
* **#63** (`Adding DN of eScience CA 3B and 3A...` by @DonaldChung-HK): Updates for eScience CA 3A and 3B Subject DNs in CertWizard.

---

### Testing & Verification

* [x] Verified local build succeeds on Java 25 (`mvn package`).
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.716 s
[INFO] Finished at: 2026-07-22T10:20:24+01:00
[INFO] ------------------------------------------------------------------------
```
* [x] Confirmed `package.yml` GitHub Action workflow triggers and executes cleanly without path-resolution errors. (See artifact here: https://github.com/stfc/CertWizard/actions/runs/29862041861)
* [x] Validated certificate import/renew/revoke logic with certs having the issued by eScience CA 3A/3B DNs.