### PR TITLE
Add macOS Intel build and fix mac code signing via jpackage

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: Package Multiplatform Installers
 on:
   release:
     types: [ published ]
-  workflow_dispatch: # Allows manual triggering from the Actions tab for any branch
+  workflow_dispatch:
     inputs:
       test_mode:
         description: 'Is this a test run? (Saves files to Action run instead of updating a live Release)'
@@ -20,7 +20,7 @@ jobs:
   build-and-package:
     name: Package for ${{ matrix.friendly-name }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -28,21 +28,24 @@ jobs:
           - os: windows-latest
             friendly-name: Windows (EXE & Portable Zip)
             platform-profile: jar-with-dependencies
-            # Captures both the executable setup installer and the portable zip ball
             artifact-path: |
               target/CertWizard_*.exe
-              target/CertWizard_*.msi
               target/CertWizard-windows.zip
             artifact-name: CertWizard-Windows
 
           - os: macos-latest
-            friendly-name: macOS (DMG/PKG/Zip)
-            platform-profile: jar-with-dependencies
+            friendly-name: macOS Apple Silicon (DMG/PKG/Zip)
+            platform-profile: jar-with-dependencies,package-mac
             artifact-path: |
               target/CertWizard-mac.zip
-              target/*.dmg
-              target/*.pkg
-            artifact-name: CertWizard-Mac-App
+            artifact-name: CertWizard-Mac-ARM64-APP
+
+          - os: macos-26-intel
+            friendly-name: macOS Intel (DMG/PKG/Zip)
+            platform-profile: jar-with-dependencies,package-mac
+            artifact-path: |
+              target/CertWizard-mac.zip
+            artifact-name: CertWizard-Mac-x64-APP
 
           - os: ubuntu-latest
             friendly-name: Linux (JAR)
@@ -68,7 +71,7 @@ jobs:
       - name: Build and Native Package with Maven
         run: mvn clean package -P ${{ matrix.platform-profile }}
 
-      # 4. Archive and upload the generated artifacts
+      # 4. Upload artifacts
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -208,21 +208,155 @@
                                     </winConfig>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--
+            macOS packaging uses the JDK's own jpackage instead of fvarrui/javapackager.
+            javapackager's mac launcher (universalJavaApplicationStub) is a shell script,
+            not a Mach-O binary, and rcodesign can't sign a bundle whose CFBundleExecutable
+            isn't Mach-O ("Invalid magic number" errors). jpackage emits a real compiled
+            launcher, which both codesign and rcodesign can sign correctly. This profile
+            is only auto-activated when running on a Mac (jpackage cannot cross-build mac
+            app images from another OS anyway).
+        -->
+        <profile>
+            <id>package-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
                             <execution>
-                            <id>bundling-for-mac</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>package</goal>
-                            </goals>
-                            <configuration>
-                                <platform>mac</platform>
-                                <createZipball>true</createZipball>
-                                <bundleJre>true</bundleJre>
-                                <macConfig>
-                                    <icnsFile>src/main/resources/ngs-icon.icns</icnsFile>
-                                </macConfig>
-                            </configuration>
-                        </execution>
+                                <id>stage-jpackage-input</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/jpackage-input</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>${project.build.finalName}-jar-with-dependencies.jar</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>jpackage-mac-app-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/jpackage</executable>
+                                    <arguments>
+                                        <argument>--type</argument>
+                                        <argument>app-image</argument>
+                                        <argument>--name</argument>
+                                        <argument>CertWizard</argument>
+                                        <argument>--input</argument>
+                                        <argument>${project.build.directory}/jpackage-input</argument>
+                                        <argument>--main-jar</argument>
+                                        <argument>${project.build.finalName}-jar-with-dependencies.jar</argument>
+                                        <argument>--main-class</argument>
+                                        <argument>${mainClass}</argument>
+                                        <argument>--dest</argument>
+                                        <argument>${project.build.directory}</argument>
+                                        <argument>--app-version</argument>
+                                        <argument>${project.version}</argument>
+                                        <argument>--vendor</argument>
+                                        <argument>STFC</argument>
+                                        <argument>--copyright</argument>
+                                        <argument>STFC</argument>
+                                        <argument>--icon</argument>
+                                        <argument>${project.basedir}/src/main/resources/ngs-icon.icns</argument>
+                                        <argument>--mac-package-identifier</argument>
+                                        <argument>uk.ngs.certwizard</argument>
+                                        <argument>--mac-package-name</argument>
+                                        <argument>CertWizard</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!--
+                                    Contents/runtime/Contents/Info.plist declares libjli.dylib as
+                                    CFBundleExecutable, which is what makes rcodesign treat
+                                    Contents/runtime as a nested bundle with a "main executable" to sign
+                                    specially. That file also gets swept up generically while signing
+                                    Contents/Home/lib/*.dylib, so it ends up processed twice under two
+                                    different roles - and Apple's notary service then rejects it with
+                                    "The signature of the binary is invalid." for that path. This is a
+                                    known, long-standing jpackage quirk independent of any one signing
+                                    tool (OpenJDK JDK-8237490; codesign-based scripts have hit the same
+                                    Contents/runtime/Contents/MacOS/libjli.dylib failure). Stripping
+                                    CFBundleExecutable means rcodesign no longer recognizes
+                                    Contents/runtime as a bundle with a main executable at all - it
+                                    already handles that case gracefully ("bundle has no main executable
+                                    to sign specially", seen earlier in this same pipeline), so
+                                    libjli.dylib just gets signed once, generically, like every other
+                                    dylib in the runtime.
+                                -->
+                                <id>strip-runtime-bundle-executable</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>python3</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>
+import plistlib, sys, os
+p = sys.argv[1]
+if os.path.exists(p):
+    with open(p, 'rb') as f:
+        d = plistlib.load(f)
+    d.pop('CFBundleExecutable', None)
+    with open(p, 'wb') as f:
+        plistlib.dump(d, f)
+                                        </argument>
+                                        <argument>${project.build.directory}/CertWizard.app/Contents/runtime/Contents/Info.plist</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>zip-mac-app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>ditto</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>-k</argument>
+                                        <argument>--keepParent</argument>
+                                        <argument>${project.build.directory}/CertWizard.app</argument>
+                                        <argument>${project.build.directory}/CertWizard-mac.zip</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary
- Add a `macos-26-intel` matrix entry to `package.yml` so the release pipeline builds both Apple Silicon (arm64) and Intel (x64) macOS artifacts, alongside the existing Windows/Linux builds.
- Switch mac packaging from `fvarrui/javapackager`'s mac bundler to the JDK's own `jpackage` (new `package-mac` Maven profile, auto-activated on macOS): javapackager's launcher script isn't a Mach-O binary, so `rcodesign` couldn't sign it ("Invalid magic number").
- Strip `CFBundleExecutable` from `Contents/runtime/Contents/Info.plist` before signing, working around a known jpackage quirk (OpenJDK JDK-8237490) where `libjli.dylib` otherwise gets signed twice and notarization rejects it.
- Trim build artifact target list to shrink the artifact bundle.

## Test plan
- [*] Trigger the `Package Multiplatform Installers` workflow (`workflow_dispatch`, test mode) and confirm both `CertWizard-Mac-ARM64-APP` and `CertWizard-Mac-x64-APP` artifacts build and sign successfully.
- [*] Manually signed and notarised the the produced `.app` with `rcodesign` successfully.
- [*] Manual testing by macbook owners that it can run and passed notarisation gate.
